### PR TITLE
feat: k6 부하 테스트

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.webjars:sockjs-client:1.5.1'
     implementation 'org.webjars:stomp-websocket:2.3.4'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/k6/check-threads.sh
+++ b/k6/check-threads.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+curl -s localhost:8080/actuator/metrics/jvm.threads.live \
+  | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+v = next(m['value'] for m in d['measurements'] if m['statistic'] == 'VALUE')
+print(f'JVM live threads: {int(v)}')
+"

--- a/k6/rest-test.js
+++ b/k6/rest-test.js
@@ -1,0 +1,113 @@
+/**
+ * k6 REST API Load Test
+ *
+ * Scenario A: Platform Thread Saturation
+ * - Ramp up to 200 VUs over 30s, hold for 60s, ramp down over 15s
+ * - Each VU: POST /api/rooms → GET /api/rooms (repeated)
+ * - Measures: RPS, P50/P95/P99 latency, error rate, JVM thread count
+ *
+ * Run:
+ *   k6 run k6/rest-test.js
+ *   k6 run --out json=results/rest-platform.json k6/rest-test.js
+ */
+
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Counter, Rate, Trend } from 'k6/metrics';
+
+const BASE_URL = 'http://localhost:8080';
+
+// Custom metrics
+const createRoomErrors = new Counter('create_room_errors');
+const listRoomErrors   = new Counter('list_room_errors');
+const errorRate        = new Rate('error_rate');
+const createLatency    = new Trend('create_room_latency', true);
+const listLatency      = new Trend('list_room_latency', true);
+
+export const options = {
+  stages: [
+    { duration: '30s', target: 200 }, // ramp-up
+    { duration: '60s', target: 200 }, // sustained load
+    { duration: '15s', target: 0   }, // ramp-down
+  ],
+  thresholds: {
+    // Alert if P99 exceeds 1s or error rate exceeds 1%
+    http_req_duration:   ['p(99)<1000'],
+    error_rate:          ['rate<0.01'],
+    create_room_latency: ['p(95)<500'],
+    list_room_latency:   ['p(95)<200'],
+  },
+};
+
+export default function () {
+  const vuId    = __VU;
+  const userId  = `user-${vuId}`;
+  const headers = { 'Content-Type': 'application/json' };
+
+  // --- POST /api/rooms ---
+  const createPayload = JSON.stringify({
+    roomName:  `room-vu${vuId}-${Date.now()}`,
+    creatorId: userId,
+  });
+
+  const createRes = http.post(`${BASE_URL}/api/rooms`, createPayload, { headers });
+
+  const createOk = check(createRes, {
+    'create room status 201': (r) => r.status === 201,
+    'create room has roomId': (r) => {
+      try { return JSON.parse(r.body).roomId !== undefined; }
+      catch { return false; }
+    },
+  });
+
+  createLatency.add(createRes.timings.duration);
+
+  if (!createOk) {
+    createRoomErrors.add(1);
+    errorRate.add(1);
+  } else {
+    errorRate.add(0);
+  }
+
+  // Small pause to simulate realistic user behaviour
+  sleep(0.1);
+
+  // --- GET /api/rooms ---
+  const listRes = http.get(`${BASE_URL}/api/rooms`);
+
+  const listOk = check(listRes, {
+    'list rooms status 200': (r) => r.status === 200,
+    'list rooms is array':   (r) => {
+      try { return Array.isArray(JSON.parse(r.body)); }
+      catch { return false; }
+    },
+  });
+
+  listLatency.add(listRes.timings.duration);
+
+  if (!listOk) {
+    listRoomErrors.add(1);
+    errorRate.add(1);
+  } else {
+    errorRate.add(0);
+  }
+
+  sleep(0.1);
+}
+
+/**
+ * Print a summary of JVM thread count at test end.
+ * Run the server with Actuator enabled; this queries metrics.
+ */
+export function teardown() {
+  const res = http.get(`${BASE_URL}/actuator/metrics/jvm.threads.live`);
+  if (res.status === 200) {
+    try {
+      const data = JSON.parse(res.body);
+      const value = data.measurements.find((m) => m.statistic === 'VALUE');
+      console.log(`\n[Actuator] JVM live threads at end of test: ${value ? value.value : 'N/A'}`);
+    } catch (e) {
+      console.log('[Actuator] Failed to parse thread metrics');
+    }
+  }
+}

--- a/k6/ws-stomp-test.js
+++ b/k6/ws-stomp-test.js
@@ -190,7 +190,8 @@ export default function () {
 
         // ── Step 5: JOIN ─────────────────────────────────────────
         socket.send(stompFrame('SEND', {
-          destination: '/app/room.join',
+          destination:    '/app/room.join',
+          'content-type': 'application/json',
         }, JSON.stringify({ roomId, userId })));
       }
 
@@ -202,13 +203,13 @@ export default function () {
         // Track round-trip for CHAT messages we sent
         try {
           const body = JSON.parse(frame.body);
-          if (body.sender === userId && sendTimestamps[body.content]) {
+          if (body.senderId === userId && sendTimestamps[body.content]) {
             msgRoundTrip.add(Date.now() - sendTimestamps[body.content]);
             delete sendTimestamps[body.content];
           }
 
           // After JOIN confirmation, start sending chat messages
-          if (!joined && body.type === 'JOIN' && body.sender === userId) {
+          if (!joined && body.type === 'JOIN' && body.senderId === userId) {
             joined = true;
             // ── Step 6: Send 20 messages (100ms apart) ────────────
             let i = 0;
@@ -216,7 +217,8 @@ export default function () {
               if (i >= MESSAGES_PER_VU) {
                 // ── Step 7: LEAVE ──────────────────────────────
                 socket.send(stompFrame('SEND', {
-                  destination: '/app/room.leave',
+                  destination:    '/app/room.leave',
+                  'content-type': 'application/json',
                 }, JSON.stringify({ roomId, userId })));
                 return;
               }
@@ -225,7 +227,7 @@ export default function () {
               socket.send(stompFrame('SEND', {
                 destination:   '/app/room.send',
                 'content-type': 'application/json',
-              }, JSON.stringify({ roomId, sender: userId, content, type: 'CHAT' })));
+              }, JSON.stringify({ roomId, senderId: userId, content, type: 'CHAT' })));
               msgSent.add(1);
               i++;
               socket.setTimeout(sendNext, 100);
@@ -234,7 +236,7 @@ export default function () {
           }
 
           // After LEAVE or ROOM_DELETED, close the connection
-          if (body.type === 'LEAVE' && body.sender === userId) {
+          if (body.type === 'LEAVE' && body.senderId === userId) {
             socket.close();
           }
           if (body.type === 'ROOM_DELETED') {

--- a/k6/ws-stomp-test.js
+++ b/k6/ws-stomp-test.js
@@ -1,0 +1,286 @@
+/**
+ * k6 WebSocket STOMP Load Test
+ *
+ * Scenario B: Concurrent WebSocket Connections + Message Throughput
+ * - Staged ramp: 0 → 100 → 500 → 1000 concurrent connections
+ * - Each VU:
+ *     1. POST /api/rooms  (create a private room)
+ *     2. Open SockJS WebSocket  ws://localhost:8080/ws/{server}/{session}/websocket
+ *     3. STOMP CONNECT
+ *     4. SUBSCRIBE /topic/room/<roomId>
+ *     5. STOMP SEND /app/room.join
+ *     6. Send 20 chat messages (100 ms apart)
+ *     7. STOMP SEND /app/room.leave
+ *     8. Close connection
+ * - Measures: concurrent connections, msg throughput, P99 latency, JVM threads
+ *
+ * Run:
+ *   k6 run k6/ws-stomp-test.js
+ *   k6 run --out json=results/ws-platform.json k6/ws-stomp-test.js
+ */
+
+import http from 'k6/http';
+import ws   from 'k6/ws';
+import { check, sleep } from 'k6';
+import { Counter, Rate, Trend, Gauge } from 'k6/metrics';
+
+const BASE_URL    = 'http://localhost:8080';
+const WS_BASE_URL = 'ws://localhost:8080';
+const MESSAGES_PER_VU = 20;
+
+// Custom metrics
+const wsConnectErrors  = new Counter('ws_connect_errors');
+const stompErrors      = new Counter('stomp_errors');
+const msgSent          = new Counter('messages_sent');
+const msgReceived      = new Counter('messages_received');
+const errorRate        = new Rate('ws_error_rate');
+const wsConnectTime    = new Trend('ws_connect_duration_ms', true);
+const msgRoundTrip     = new Trend('msg_roundtrip_ms', true);
+
+export const options = {
+  stages: [
+    { duration: '20s', target: 100  }, // 0 → 100  connections
+    { duration: '30s', target: 100  }, // hold
+    { duration: '30s', target: 500  }, // 100 → 500
+    { duration: '30s', target: 500  }, // hold
+    { duration: '30s', target: 1000 }, // 500 → 1000
+    { duration: '30s', target: 1000 }, // hold
+    { duration: '20s', target: 0    }, // ramp-down
+  ],
+  thresholds: {
+    ws_error_rate:         ['rate<0.05'],   // <5 % WS errors acceptable
+    ws_connect_duration_ms: ['p(95)<3000'], // connect within 3s
+    msg_roundtrip_ms:       ['p(99)<2000'], // echo within 2s
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Generate a random alphanumeric session/server id like SockJS expects */
+function randId(len) {
+  const chars = 'abcdefghijklmnopqrstuvwxyz0123456789';
+  let s = '';
+  for (let i = 0; i < len; i++) s += chars[Math.floor(Math.random() * chars.length)];
+  return s;
+}
+
+/**
+ * Encode a STOMP frame to a string.
+ * SockJS wraps it as:  ["STOMP_FRAME_STRING"]
+ */
+function stompFrame(command, headers, body) {
+  let frame = command + '\n';
+  for (const [k, v] of Object.entries(headers)) {
+    frame += `${k}:${v}\n`;
+  }
+  frame += '\n';
+  if (body) frame += body;
+  frame += '\x00';
+  return JSON.stringify([frame]); // SockJS array wrap
+}
+
+function parseStompFrame(raw) {
+  // raw is like  a["STOMP_FRAME"]
+  if (!raw || raw === 'h' || raw === 'o') return null;
+  if (!raw.startsWith('a')) return null;
+  try {
+    const arr = JSON.parse(raw.slice(1));
+    if (!Array.isArray(arr) || arr.length === 0) return null;
+    const text = arr[0];
+    const lines = text.split('\n');
+    const command = lines[0];
+    const hdrs = {};
+    let i = 1;
+    while (i < lines.length && lines[i] !== '') {
+      const [k, ...rest] = lines[i].split(':');
+      hdrs[k] = rest.join(':');
+      i++;
+    }
+    const bodyStart = text.indexOf('\n\n') + 2;
+    const body = text.slice(bodyStart).replace('\x00', '');
+    return { command, headers: hdrs, body };
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main VU function
+// ---------------------------------------------------------------------------
+
+export default function () {
+  const vuId   = __VU;
+  const iterId = __ITER;
+  const userId = `vu${vuId}-iter${iterId}`;
+
+  // ── Step 1: Create a private room via REST ──────────────────────────────
+  const createRes = http.post(
+    `${BASE_URL}/api/rooms`,
+    JSON.stringify({ roomName: `bench-${userId}`, creatorId: userId }),
+    { headers: { 'Content-Type': 'application/json' } },
+  );
+
+  const createOk = check(createRes, { 'room created (201)': (r) => r.status === 201 });
+  if (!createOk) {
+    errorRate.add(1);
+    wsConnectErrors.add(1);
+    return;
+  }
+  errorRate.add(0);
+
+  let roomId;
+  try {
+    roomId = JSON.parse(createRes.body).roomId;
+  } catch {
+    wsConnectErrors.add(1);
+    return;
+  }
+
+  // ── Step 2: Open SockJS/WebSocket ──────────────────────────────────────
+  const serverId  = Math.floor(Math.random() * 900 + 100).toString(); // 3-digit
+  const sessionId = randId(8);
+  const wsUrl     = `${WS_BASE_URL}/ws/${serverId}/${sessionId}/websocket`;
+
+  const connectStart = Date.now();
+
+  const res = ws.connect(wsUrl, {}, function (socket) {
+    let connected      = false;
+    let subscribed     = false;
+    let joined         = false;
+    let sentCount      = 0;
+    let receivedCount  = 0;
+    let sendTimestamps = {};
+
+    // ── Timeout guard: close after 30s regardless ─────────────────────
+    socket.setTimeout(function () {
+      socket.close();
+    }, 30000);
+
+    socket.on('open', function () {
+      wsConnectTime.add(Date.now() - connectStart);
+
+      // ── Step 3: STOMP CONNECT ─────────────────────────────────────
+      socket.send(stompFrame('CONNECT', {
+        'accept-version': '1.2',
+        'heart-beat':     '0,0',
+      }));
+    });
+
+    socket.on('message', function (data) {
+      // SockJS open frame
+      if (data === 'o') return;
+      // SockJS heartbeat
+      if (data === 'h') return;
+
+      const frame = parseStompFrame(data);
+      if (!frame) return;
+
+      // ── STOMP CONNECTED → subscribe + join ───────────────────────
+      if (frame.command === 'CONNECTED' && !connected) {
+        connected = true;
+
+        // ── Step 4: SUBSCRIBE ────────────────────────────────────
+        socket.send(stompFrame('SUBSCRIBE', {
+          id:          `sub-${vuId}`,
+          destination: `/topic/room/${roomId}`,
+        }));
+        subscribed = true;
+
+        // ── Step 5: JOIN ─────────────────────────────────────────
+        socket.send(stompFrame('SEND', {
+          destination: '/app/room.join',
+        }, JSON.stringify({ roomId, userId })));
+      }
+
+      // ── Incoming MESSAGE frame ─────────────────────────────────────
+      if (frame.command === 'MESSAGE') {
+        receivedCount++;
+        msgReceived.add(1);
+
+        // Track round-trip for CHAT messages we sent
+        try {
+          const body = JSON.parse(frame.body);
+          if (body.sender === userId && sendTimestamps[body.content]) {
+            msgRoundTrip.add(Date.now() - sendTimestamps[body.content]);
+            delete sendTimestamps[body.content];
+          }
+
+          // After JOIN confirmation, start sending chat messages
+          if (!joined && body.type === 'JOIN' && body.sender === userId) {
+            joined = true;
+            // ── Step 6: Send 20 messages (100ms apart) ────────────
+            let i = 0;
+            const sendNext = function () {
+              if (i >= MESSAGES_PER_VU) {
+                // ── Step 7: LEAVE ──────────────────────────────
+                socket.send(stompFrame('SEND', {
+                  destination: '/app/room.leave',
+                }, JSON.stringify({ roomId, userId })));
+                return;
+              }
+              const content = `msg-${i}-from-${userId}`;
+              sendTimestamps[content] = Date.now();
+              socket.send(stompFrame('SEND', {
+                destination:   '/app/room.send',
+                'content-type': 'application/json',
+              }, JSON.stringify({ roomId, sender: userId, content, type: 'CHAT' })));
+              msgSent.add(1);
+              i++;
+              socket.setTimeout(sendNext, 100);
+            };
+            sendNext();
+          }
+
+          // After LEAVE or ROOM_DELETED, close the connection
+          if (body.type === 'LEAVE' && body.sender === userId) {
+            socket.close();
+          }
+          if (body.type === 'ROOM_DELETED') {
+            socket.close();
+          }
+        } catch {
+          // ignore JSON parse errors on non-chat messages
+        }
+      }
+
+      // ── ERROR frame ────────────────────────────────────────────────
+      if (frame.command === 'ERROR') {
+        stompErrors.add(1);
+        errorRate.add(1);
+        socket.close();
+      }
+    });
+
+    socket.on('error', function (e) {
+      wsConnectErrors.add(1);
+      errorRate.add(1);
+    });
+
+    socket.on('close', function () {
+      errorRate.add(0); // mark as non-error close
+    });
+  });
+
+  check(res, { 'ws status 101': (r) => r && r.status === 101 });
+
+  // Give VU a short rest before next iteration
+  sleep(1);
+}
+
+// ---------------------------------------------------------------------------
+// teardown – print JVM thread count
+// ---------------------------------------------------------------------------
+export function teardown() {
+  const res = http.get(`${BASE_URL}/actuator/metrics/jvm.threads.live`);
+  if (res.status === 200) {
+    try {
+      const data  = JSON.parse(res.body);
+      const value = data.measurements.find((m) => m.statistic === 'VALUE');
+      console.log(`\n[Actuator] JVM live threads at end of test: ${value ? value.value : 'N/A'}`);
+    } catch {
+      console.log('[Actuator] Failed to parse thread metrics');
+    }
+  }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,8 @@
 spring.application.name=websoket-vtualTread-test
+
+# Actuator - metrics exposure for load test monitoring
+management.endpoints.web.exposure.include=metrics,health
+management.endpoint.metrics.enabled=true
+
+# Virtual Thread toggle (uncomment for Phase 2)
+spring.threads.virtual.enabled=true


### PR DESCRIPTION
# spring.threads.virtual.enabled=true 설정 전 rest-test.js 테스트

~~~
sunmin@iseonmin-ui-MacBookPro websoket-vtualTread-test % k6 run k6/rest-test.js

         /\      Grafana   /‾‾/                                                                                                                                                      
    /\  /  \     |\  __   /  /                                                                                                                                                       
   /  \/    \    | |/ /  /   ‾‾\                                                                                                                                                     
  /          \   |   (  |  (‾)  |                                                                                                                                                    
 / __________ \  |_|\_\  \_____/ 


     execution: local
        script: k6/rest-test.js
        output: -

     scenarios: (100.00%) 1 scenario, 200 max VUs, 2m15s max duration (incl. graceful stop):
              * default: Up to 200 looping VUs for 1m45s over 3 stages (gracefulRampDown: 30s, gracefulStop: 30s)

INFO[0105] 
[Actuator] JVM live threads at end of test: 78  source=console


  █ THRESHOLDS 

    create_room_latency
    ✓ 'p(95)<500' p(95)=379.19ms

    error_rate
    ✓ 'rate<0.01' rate=0.00%

    http_req_duration
    ✗ 'p(99)<1000' p(99)=1.42s

    list_room_latency
    ✗ 'p(95)<200' p(95)=887.58ms


  █ TOTAL RESULTS 

    checks_total.......: 65252   620.290789/s
    checks_succeeded...: 100.00% 65252 out of 65252
    checks_failed......: 0.00%   0 out of 65252

    ✓ create room status 201
    ✓ create room has roomId
    ✓ list rooms status 200
    ✓ list rooms is array

    CUSTOM
    create_room_latency............: avg=79.4ms   min=478µs    med=23.52ms  max=2.72s p(90)=131.69ms p(95)=379.19ms
    error_rate.....................: 0.00%  0 out of 32626
    list_room_latency..............: avg=157.67ms min=404µs    med=37.11ms  max=3.44s p(90)=438.94ms p(95)=887.58ms

    HTTP
    http_req_duration..............: avg=118.53ms min=404µs    med=28.45ms  max=3.44s p(90)=268.45ms p(95)=674.1ms 
      { expected_response:true }...: avg=118.53ms min=404µs    med=28.45ms  max=3.44s p(90)=268.45ms p(95)=674.1ms 
    http_req_failed................: 0.00%  0 out of 32627
    http_reqs......................: 32627  310.1549/s

    EXECUTION
    iteration_duration.............: avg=1.01s    min=202.46ms med=618.57ms max=7.41s p(90)=2.39s    p(95)=3.05s   
    iterations.....................: 16313  155.072697/s
    vus............................: 2      min=2          max=200
    vus_max........................: 200    min=200        max=200

    NETWORK
    data_received..................: 25 GB  236 MB/s
    data_sent......................: 4.4 MB 42 kB/s




running (1m45.2s), 000/200 VUs, 16313 complete and 0 interrupted iterations
default ✓ [======================================] 000/200 VUs  1m45s
ERRO[0105] thresholds on metrics 'http_req_duration, list_room_latency' have been crossed
~~~

~~~
Every 1.0s: k6/check-threads.sh
  iseonmin-ui-MacBookPro.local: 일  3/ 1 19:22:28 2026

                in 0.034s (0)
  JVM live threads: 78
~~~

# # spring.threads.virtual.enabled=true 설정 후 rest-test.js 테스트

~~~
sunmin@iseonmin-ui-MacBookPro websoket-vtualTread-test % k6 run k6/rest-test.js          

         /\      Grafana   /‾‾/                                                                                                                                                      
    /\  /  \     |\  __   /  /                                                                                                                                                       
   /  \/    \    | |/ /  /   ‾‾\                                                                                                                                                     
  /          \   |   (  |  (‾)  |                                                                                                                                                    
 / __________ \  |_|\_\  \_____/ 


     execution: local
        script: k6/rest-test.js
        output: -

     scenarios: (100.00%) 1 scenario, 200 max VUs, 2m15s max duration (incl. graceful stop):
              * default: Up to 200 looping VUs for 1m45s over 3 stages (gracefulRampDown: 30s, gracefulStop: 30s)

INFO[0105] 
[Actuator] JVM live threads at end of test: 81  source=console


  █ THRESHOLDS 

    create_room_latency
    ✓ 'p(95)<500' p(95)=409.17ms

    error_rate
    ✓ 'rate<0.01' rate=0.00%

    http_req_duration
    ✗ 'p(99)<1000' p(99)=1.27s

    list_room_latency
    ✗ 'p(95)<200' p(95)=844.08ms


  █ TOTAL RESULTS 

    checks_total.......: 69212   658.657279/s
    checks_succeeded...: 100.00% 69212 out of 69212
    checks_failed......: 0.00%   0 out of 69212

    ✓ create room status 201
    ✓ create room has roomId
    ✓ list rooms status 200
    ✓ list rooms is array

    CUSTOM
    create_room_latency............: avg=75.48ms  min=707µs   med=23.47ms max=2.22s p(90)=127.99ms p(95)=409.17ms
    error_rate.....................: 0.00%  0 out of 34606
    list_room_latency..............: avg=152.32ms min=611µs   med=37.96ms max=3.02s p(90)=467.9ms  p(95)=844.08ms

    HTTP
    http_req_duration..............: avg=113.9ms  min=611µs   med=28.58ms max=3.02s p(90)=281.78ms p(95)=665.7ms 
      { expected_response:true }...: avg=113.9ms  min=611µs   med=28.58ms max=3.02s p(90)=281.78ms p(95)=665.7ms 
    http_req_failed................: 0.00%  0 out of 34607
    http_reqs......................: 34607  329.338156/s

    EXECUTION
    iteration_duration.............: avg=952.76ms min=202.2ms med=587.5ms max=7.54s p(90)=2.22s    p(95)=2.76s   
    iterations.....................: 17303  164.66432/s
    vus............................: 3      min=3          max=200
    vus_max........................: 200    min=200        max=200

    NETWORK
    data_received..................: 28 GB  265 MB/s
    data_sent......................: 4.7 MB 45 kB/s




running (1m45.1s), 000/200 VUs, 17303 complete and 0 interrupted iterations
default ✓ [======================================] 000/200 VUs  1m45s
ERRO[0105] thresholds on metrics 'http_req_duration, list_room_latency' have been crossed 
~~~

~~~
Every 1.0s: k6/check-threa… iseonmin-ui-MacBookPro.local: 일  3/ 1 20:27:49 2026
                                                                   in 0.041s (0)
JVM live threads: 81
~~~

변화가 크게 없는 이유 1: 이 앱에 블로킹 I/O가 없음 (더 근본적인 원인)

Virtual Thread의 핵심 이점은 블로킹 I/O 대기 중 carrier thread를 다른 VT에게 양보하는 것입니다.

DB 쿼리, 외부 HTTP 호출, 파일 I/O → 쓰레드 블록 → VT가 carrier 반납 → 효율 극대화

이 앱은 전부 인메모리 ConcurrentHashMap 연산이라 블로킹 자체가 없습니다.
→ VT가 양보할 기회 없음 → 플랫폼 쓰레드와 동일한 동작

  ---
 변화가 크게 없는 이유 2:  — Pinning 발생 중 (Java 21 한계)

~~~
  // ChatRoomStore.java:34
  public synchronized boolean joinRoom(String roomId, String userId) {
~~~

  Java 21에서 synchronized 블록 안에서 VT가 블록되면 carrier thread에 고정(pinned) 됩니다. JEP 491로 이 문제가 해결된 건 Java 24입니다.

REST 테스트에서 joinRoom()은 호출 안 되지만, broadcastRoomList() → SimpleMessageBroker 내부에도 synchronized가 있어 pinning이 발생합니다.

Pinning에 대한 더 자세한 내용은 블로그(https://sunm2n.tistory.com/91) 에 정리해두었습니다.


# pring.threads.virtual.enabled=true 설정 전 ws-stomp-test.js 테스트

~~~
sunmin@iseonmin-ui-MacBookPro websoket-vtualTread-test % k6 run k6/ws-stomp-test.js      

         /\      Grafana   /‾‾/                                                                                                                                                      
    /\  /  \     |\  __   /  /                                                                                                                                                       
   /  \/    \    | |/ /  /   ‾‾\                                                                                                                                                     
  /          \   |   (  |  (‾)  |                                                                                                                                                    
 / __________ \  |_|\_\  \_____/ 


     execution: local
        script: k6/ws-stomp-test.js
        output: -

     scenarios: (100.00%) 1 scenario, 1000 max VUs, 3m40s max duration (incl. graceful stop):
              * default: Up to 1000 looping VUs for 3m10s over 7 stages (gracefulRampDown: 30s, gracefulStop: 30s)

WARN[0148] The test has generated metrics with 100129 unique time series, which is higher than the suggested limit of 100000 and could cause high memory usage. Consider not using high-cardinality values like unique IDs as metric tags or, if you need them in the URL, use the name metric tag or URL grouping. See https://grafana.com/docs/k6/latest/using-k6/tags-and-groups/ for details.  component=metrics-engine-ingester
INFO[0208] 
[Actuator] JVM live threads at end of test: 217  source=console


  █ THRESHOLDS 

    msg_roundtrip_ms
    ✓ 'p(99)<2000' p(99)=5ms

    ws_connect_duration_ms
    ✓ 'p(95)<3000' p(95)=3ms

    ws_error_rate
    ✓ 'rate<0.05' rate=0.00%


  █ TOTAL RESULTS 

    checks_total.......: 60956   292.513634/s
    checks_succeeded...: 100.00% 60956 out of 60956
    checks_failed......: 0.00%   0 out of 60956

    ✓ room created (201)
    ✓ ws status 101

    CUSTOM
    messages_received..............: 670252 3216.383098/s
    messages_sent..................: 609320 2923.984634/s
    msg_roundtrip_ms...............: avg=756.82µs min=0s       med=1ms      max=18ms    p(90)=2ms    p(95)=3ms   

    HTTP
    http_req_duration..............: avg=1.41ms   min=314µs    med=1.07ms   max=13.62ms p(90)=2.51ms p(95)=3.47ms
      { expected_response:true }...: avg=1.41ms   min=314µs    med=1.07ms   max=13.62ms p(90)=2.51ms p(95)=3.47ms
    http_req_failed................: 0.00%  0 out of 30479
    http_reqs......................: 30479  146.261616/s

    EXECUTION
    iteration_duration.............: avg=3.02s    min=3s       med=3s       max=31s     p(90)=3.02s  p(95)=3.02s 
    iterations.....................: 30477  146.252018/s
    vus............................: 1      min=1          max=1000
    vus_max........................: 1000   min=1000       max=1000

    NETWORK
    data_received..................: 270 MB 1.3 MB/s
    data_sent......................: 165 MB 791 kB/s

    WEBSOCKET
    ws_connect_duration_ms.........: avg=942.41µs min=0s       med=1ms      max=12ms    p(90)=2ms    p(95)=3ms   
    ws_connecting..................: avg=895.79µs min=156.29µs med=587.62µs max=11.04ms p(90)=1.7ms  p(95)=2.64ms
    ws_error_rate..................: 0.00%  0 out of 60956
    ws_msgs_received...............: 731220 3508.954317/s
    ws_msgs_sent...................: 731220 3508.954317/s
    ws_session_duration............: avg=2.02s    min=2s       med=2s       max=30s     p(90)=2.01s  p(95)=2.02s 
    ws_sessions....................: 30478  146.256817/s




running (3m28.4s), 0000/1000 VUs, 30477 complete and 1 interrupted iterations
default ✓ [======================================] 0000/1000 VUs  3m10s
~~~

~~~
Every 1.0s: k6/check-threa… iseonmin-ui-MacBookPro.local: 일  3/ 1 21:03:14 2026
                                                                   in 0.040s (0)
JVM live threads: 141

~~~

# pring.threads.virtual.enabled=true 설정후 ws-stomp-test.js 테스트

~~~
sunmin@iseonmin-ui-MacBookPro websoket-vtualTread-test % k6 run k6/ws-stomp-test.js    

         /\      Grafana   /‾‾/                                                                                                                                                      
    /\  /  \     |\  __   /  /                                                                                                                                                       
   /  \/    \    | |/ /  /   ‾‾\                                                                                                                                                     
  /          \   |   (  |  (‾)  |                                                                                                                                                    
 / __________ \  |_|\_\  \_____/ 


     execution: local
        script: k6/ws-stomp-test.js
        output: -

     scenarios: (100.00%) 1 scenario, 1000 max VUs, 3m40s max duration (incl. graceful stop):
              * default: Up to 1000 looping VUs for 3m10s over 7 stages (gracefulRampDown: 30s, gracefulStop: 30s)

WARN[0148] The test has generated metrics with 100111 unique time series, which is higher than the suggested limit of 100000 and could cause high memory usage. Consider not using high-cardinality values like unique IDs as metric tags or, if you need them in the URL, use the name metric tag or URL grouping. See https://grafana.com/docs/k6/latest/using-k6/tags-and-groups/ for details.  component=metrics-engine-ingester
INFO[0211] 
[Actuator] JVM live threads at end of test: 99  source=console


  █ THRESHOLDS 

    msg_roundtrip_ms
    ✓ 'p(99)<2000' p(99)=6ms

    ws_connect_duration_ms
    ✓ 'p(95)<3000' p(95)=3ms

    ws_error_rate
    ✓ 'rate<0.05' rate=0.00%


  █ TOTAL RESULTS 

    checks_total.......: 60926   288.410934/s
    checks_succeeded...: 100.00% 60926 out of 60926
    checks_failed......: 0.00%   0 out of 60926

    ✓ room created (201)
    ✓ ws status 101

    CUSTOM
    messages_received..............: 669966 3171.478843/s
    messages_sent..................: 609060 2883.162584/s
    msg_roundtrip_ms...............: avg=807.44µs min=0s       med=1ms      max=20ms    p(90)=2ms    p(95)=3ms   

    HTTP
    http_req_duration..............: avg=1.38ms   min=246µs    med=1.07ms   max=14.62ms p(90)=2.46ms p(95)=3.39ms
      { expected_response:true }...: avg=1.38ms   min=246µs    med=1.07ms   max=14.62ms p(90)=2.46ms p(95)=3.39ms
    http_req_failed................: 0.00%  0 out of 30464
    http_reqs......................: 30464  144.210201/s

    EXECUTION
    iteration_duration.............: avg=3.02s    min=3s       med=3s       max=31.01s  p(90)=3.02s  p(95)=3.02s 
    iterations.....................: 30463  144.205467/s
    vus............................: 1      min=1          max=1000
    vus_max........................: 1000   min=1000       max=1000

    NETWORK
    data_received..................: 270 MB 1.3 MB/s
    data_sent......................: 165 MB 780 kB/s

    WEBSOCKET
    ws_connect_duration_ms.........: avg=930.07µs min=0s       med=1ms      max=12ms    p(90)=2ms    p(95)=3ms   
    ws_connecting..................: avg=877.28µs min=179.25µs med=574.75µs max=11.48ms p(90)=1.68ms p(95)=2.56ms
    ws_error_rate..................: 0.00%  0 out of 60926
    ws_msgs_received...............: 730902 3459.937115/s
    ws_msgs_sent...................: 730902 3459.937115/s
    ws_session_duration............: avg=2.01s    min=2s       med=2s       max=30.01s  p(90)=2.01s  p(95)=2.02s 
    ws_sessions....................: 30463  144.205467/s




running (3m31.2s), 0000/1000 VUs, 30463 complete and 0 interrupted iterations
default ✓ [======================================] 0000/1000 VUs  3m10s
~~~

~~~
Every 1.0s: k6/check-threa… iseonmin-ui-MacBookPro.local: 일  3/ 1 21:09:08 2026
                                                                   in 0.033s (0)
JVM live threads: 99
~~~

<img width="585" height="305" alt="image" src="https://github.com/user-attachments/assets/f8c373fa-53d9-4e4d-86ee-592b8b64e178" />

핵심 인사이트

처리량은 동일한데 쓰레드 수가 절반 -> 이게 Virtual Thread의 핵심입니다.

플랫폼 쓰레드: 1000 연결 → 217개 OS 쓰레드 필요 (Tomcat 풀 200 초과)
버추얼 쓰레드: 1000 연결 →  99개 OS 쓰레드로 처리

99개가 왜 더 낮아지지 않냐면: carrier thread(CPU 코어 수) + Spring 내부 쓰레드 + JVM 시스템 쓰레드 + WebSocket broker 쓰레드 합산입니다. 실제 Tomcat 워커는 virtual thread로 교체됐지만 나머지 플랫폼 쓰레드는 여전히 존재합니다.

처리량이 동일한 이유: 이 앱은 인메모리 연산이라 VT가 블로킹 I/O에서 carrier를
반납할 기회가 없습니다. DB나 외부 API 호출이 있었다면 처리량 차이도 났을 것입니다.
