### PR TITLE
feat: thread sleep 추가 후 테스트

### DIFF
--- a/k6/rest-blocking-test.js
+++ b/k6/rest-blocking-test.js
@@ -66,6 +66,9 @@ export default function () {
   errorRate.add(createOk ? 0 : 1);
   if (!createOk) createErrors.add(1);
 
+  let roomId = null;
+  try { roomId = JSON.parse(createRes.body).roomId; } catch { /* ignore */ }
+
   // GET /api/rooms  (서버 50ms sleep)
   const listRes = http.get(`${BASE_URL}/api/rooms`);
 
@@ -74,6 +77,11 @@ export default function () {
   const listOk = check(listRes, { 'GET 200': (r) => r.status === 200 });
   errorRate.add(listOk ? 0 : 1);
   if (!listOk) listErrors.add(1);
+
+  // DELETE: 생성한 방을 즉시 삭제 → 방 목록 누적 방지 → GET 응답 크기 일정하게 유지
+  if (roomId) {
+    http.del(`${BASE_URL}/api/rooms/${roomId}?userId=${userId}`);
+  }
 }
 
 export function teardown() {

--- a/k6/rest-blocking-test.js
+++ b/k6/rest-blocking-test.js
@@ -79,8 +79,11 @@ export default function () {
   if (!listOk) listErrors.add(1);
 
   // DELETE: 생성한 방을 즉시 삭제 → 방 목록 누적 방지 → GET 응답 크기 일정하게 유지
+  // name 태그로 URL의 고유 roomId를 그룹화하여 시계열 폭증 방지
   if (roomId) {
-    http.del(`${BASE_URL}/api/rooms/${roomId}?userId=${userId}`);
+    http.del(`${BASE_URL}/api/rooms/${roomId}?userId=${userId}`, null, {
+      tags: { name: 'DELETE /api/rooms/:id' },
+    });
   }
 }
 

--- a/k6/rest-blocking-test.js
+++ b/k6/rest-blocking-test.js
@@ -1,0 +1,90 @@
+/**
+ * k6 REST Blocking I/O Load Test
+ *
+ * 목적: Thread.sleep으로 DB I/O를 시뮬레이션하여
+ *       플랫폼 쓰레드 vs 버추얼 쓰레드 성능 차이를 수치화
+ *
+ * 핵심 원리:
+ *   - GET  /api/rooms → 서버에서 50ms sleep  (SELECT 시뮬)
+ *   - POST /api/rooms → 서버에서 100ms sleep (INSERT 시뮬)
+ *   - 600 VU 동시 접속 → Tomcat 기본 쓰레드 풀(200개) 3배 초과
+ *
+ * 플랫폼 쓰레드: 200개 쓰레드 포화 → 나머지 큐 대기 → 레이턴시 폭증
+ * 버추얼 쓰레드: sleep 중 carrier thread 반납 → 제한 없이 처리 → 레이턴시 유지
+ *
+ * Run:
+ *   # 1단계: application.properties에서 spring.threads.virtual.enabled=true 주석 처리 후 실행
+ *   k6 run k6/rest-blocking-test.js
+ *
+ *   # 2단계: spring.threads.virtual.enabled=true 활성화 후 재실행
+ *   k6 run k6/rest-blocking-test.js
+ */
+
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Counter, Rate, Trend } from 'k6/metrics';
+
+const BASE_URL = 'http://localhost:8080';
+
+const createErrors  = new Counter('create_errors');
+const listErrors    = new Counter('list_errors');
+const errorRate     = new Rate('error_rate');
+const createLatency = new Trend('create_latency_ms', true);
+const listLatency   = new Trend('list_latency_ms', true);
+
+export const options = {
+  stages: [
+    { duration: '20s', target: 100 }, // warmup
+    { duration: '30s', target: 300 }, // 300 VU: 플랫폼 쓰레드 풀(200) 초과 시작
+    { duration: '30s', target: 600 }, // 600 VU: 풀 3배 → 포화 확정
+    { duration: '60s', target: 600 }, // 60s 유지: 포화 상태 지속 측정
+    { duration: '20s', target: 0   }, // ramp-down
+  ],
+  thresholds: {
+    // 플랫폼 쓰레드 모드에서는 이 임계값을 초과할 것으로 예상
+    // 버추얼 쓰레드 모드에서는 통과할 것으로 예상
+    error_rate:        ['rate<0.01'],
+    create_latency_ms: ['p(99)<500'],  // 100ms sleep + 여유 400ms
+    list_latency_ms:   ['p(99)<300'],  // 50ms sleep + 여유 250ms
+  },
+};
+
+export default function () {
+  const vuId   = __VU;
+  const userId = `user-${vuId}`;
+
+  // POST /api/rooms  (서버 100ms sleep)
+  const createRes = http.post(
+    `${BASE_URL}/api/rooms`,
+    JSON.stringify({ roomName: `room-vu${vuId}-${Date.now()}`, creatorId: userId }),
+    { headers: { 'Content-Type': 'application/json' } },
+  );
+
+  createLatency.add(createRes.timings.duration);
+
+  const createOk = check(createRes, { 'POST 201': (r) => r.status === 201 });
+  errorRate.add(createOk ? 0 : 1);
+  if (!createOk) createErrors.add(1);
+
+  // GET /api/rooms  (서버 50ms sleep)
+  const listRes = http.get(`${BASE_URL}/api/rooms`);
+
+  listLatency.add(listRes.timings.duration);
+
+  const listOk = check(listRes, { 'GET 200': (r) => r.status === 200 });
+  errorRate.add(listOk ? 0 : 1);
+  if (!listOk) listErrors.add(1);
+}
+
+export function teardown() {
+  const res = http.get(`${BASE_URL}/actuator/metrics/jvm.threads.live`);
+  if (res.status === 200) {
+    try {
+      const data  = JSON.parse(res.body);
+      const value = data.measurements.find((m) => m.statistic === 'VALUE');
+      console.log(`\n[Actuator] JVM live threads at end of test: ${value ? value.value : 'N/A'}`);
+    } catch {
+      console.log('[Actuator] Failed to parse thread metrics');
+    }
+  }
+}

--- a/src/main/java/com/example/websoketvtualtreadtest/controller/RoomRestController.java
+++ b/src/main/java/com/example/websoketvtualtreadtest/controller/RoomRestController.java
@@ -14,6 +14,8 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 import java.util.UUID;
 
+// Simulates blocking I/O (e.g. DB query) to demonstrate Virtual Thread benefit
+
 @RestController
 @RequestMapping("/api/rooms")
 public class RoomRestController {
@@ -28,6 +30,7 @@ public class RoomRestController {
 
     @GetMapping
     public List<RoomResponse> listRooms() {
+        simulateDbRead();
         return store.getAllRooms().stream()
                 .map(RoomResponse::from)
                 .toList();
@@ -35,6 +38,7 @@ public class RoomRestController {
 
     @PostMapping
     public ResponseEntity<RoomResponse> createRoom(@RequestBody CreateRoomRequest req) {
+        simulateDbWrite();
         String roomId = UUID.randomUUID().toString();
         ChatRoom room = new ChatRoom(roomId, req.getRoomName(), req.getCreatorId());
         store.addRoom(room);
@@ -66,6 +70,16 @@ public class RoomRestController {
         broadcastRoomList();
 
         return ResponseEntity.noContent().build();
+    }
+
+    /** Simulates DB SELECT latency (e.g. simple read query) */
+    private void simulateDbRead() {
+        try { Thread.sleep(50); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
+    }
+
+    /** Simulates DB INSERT + commit latency */
+    private void simulateDbWrite() {
+        try { Thread.sleep(100); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
     }
 
     private void broadcastRoomList() {


### PR DESCRIPTION
# Virtual Thread 키기 전

~~~
❯ sunmin@iseonmin-ui-MacBookPro websoket-vtualTread-test % k6 run k6/rest-blocking-test.js

           /\      Grafana   /‾‾/

      /\  /  \     |\  __   /  /

     /  \/    \    | |/ /  /   ‾‾\

    /          \   |   (  |  (‾)  |

   / __________ \  |_|\_\  \_____/


       execution: local
          script: k6/rest-blocking-test.js
          output: -

       scenarios: (100.00%) 1 scenario, 600 max VUs, 3m10s max duration (incl. graceful stop):
                * default: Up to 600 looping VUs for 2m40s over 5 stages (gracefulRampDown: 30s, gracefulStop: 30s)

  WARN[0026] The test has generated metrics with 100442 unique time series, which is higher than the suggested limit of 100000 and could cause high memory usage. Consider not using
  high-cardinality values like unique IDs as metric tags or, if you need them in the URL, use the name metric tag or URL grouping. See
  https://grafana.com/docs/k6/latest/using-k6/tags-and-groups/ for details.  component=metrics-engine-ingester
  WARN[0036] The test has generated metrics with 200468 unique time series, which is higher than the suggested limit of 100000 and could cause high memory usage. Consider not using
  high-cardinality values like unique IDs as metric tags or, if you need them in the URL, use the name metric tag or URL grouping. See
  https://grafana.com/docs/k6/latest/using-k6/tags-and-groups/ for details.  component=metrics-engine-ingester
  WARN[0054] The test has generated metrics with 400142 unique time series, which is higher than the suggested limit of 100000 and could cause high memory usage. Consider not using
  high-cardinality values like unique IDs as metric tags or, if you need them in the URL, use the name metric tag or URL grouping. See
  https://grafana.com/docs/k6/latest/using-k6/tags-and-groups/ for details.  component=metrics-engine-ingester
  WARN[0088] The test has generated metrics with 800102 unique time series, which is higher than the suggested limit of 100000 and could cause high memory usage. Consider not using
  high-cardinality values like unique IDs as metric tags or, if you need them in the URL, use the name metric tag or URL grouping. See
  https://grafana.com/docs/k6/latest/using-k6/tags-and-groups/ for details.  component=metrics-engine-ingester
  INFO[0160]
  [Actuator] JVM live threads at end of test: 217  source=console


    █ THRESHOLDS

      create_latency_ms
      ✓ 'p(99)<500' p(99)=234.85ms

      error_rate
      ✓ 'rate<0.01' rate=0.00%

      list_latency_ms
      ✓ 'p(99)<300' p(99)=182.14ms


    █ TOTAL RESULTS

      checks_total.......: 353886  2209.562609/s
      checks_succeeded...: 100.00% 353886 out of 353886
      checks_failed......: 0.00%   0 out of 353886

      ✓ POST 201
      ✓ GET 200

      CUSTOM
      create_latency_ms..............: avg=168.94ms min=100.22ms med=184.75ms max=256.67ms p(90)=214.49ms p(95)=221.69ms
      error_rate.....................: 0.00%  0 out of 353886
      list_latency_ms................: avg=117.92ms min=50.17ms  med=133.21ms max=205.71ms p(90)=162.49ms p(95)=169.55ms

      HTTP
      http_req_duration..............: avg=117.79ms min=133µs    med=110.89ms max=256.67ms p(90)=203.46ms p(95)=209.4ms
        { expected_response:true }...: avg=117.79ms min=133µs    med=110.89ms max=256.67ms p(90)=203.46ms p(95)=209.4ms
      http_req_failed................: 0.00%  0 out of 530830
      http_reqs......................: 530830 3314.350157/s

      EXECUTION
      iteration_duration.............: avg=353.52ms min=151.12ms med=413.11ms max=556.1ms  p(90)=484.06ms p(95)=496.15ms
      iterations.....................: 176943 1104.781304/s
      vus............................: 1      min=1           max=600
      vus_max........................: 600    min=600         max=600

      NETWORK
      data_received..................: 8.0 GB 50 MB/s
      data_sent......................: 72 MB  450 kB/s




  running (2m40.2s), 000/600 VUs, 176943 complete and 0 interrupted iterations
  default ✓ [======================================] 000/600 VUs  2m40s
~~~

# Virtual Thread 킨 후

~~~
sunmin@iseonmin-ui-MacBookPro websoket-vtualTread-test % k6 run k6/rest-blocking-test.js

         /\      Grafana   /‾‾/                                                                                                                                                                                                          
    /\  /  \     |\  __   /  /                                                                                                                                                                                                           
   /  \/    \    | |/ /  /   ‾‾\                                                                                                                                                                                                         
  /          \   |   (  |  (‾)  |                                                                                                                                                                                                        
 / __________ \  |_|\_\  \_____/ 


     execution: local
        script: k6/rest-blocking-test.js
        output: -

     scenarios: (100.00%) 1 scenario, 600 max VUs, 3m10s max duration (incl. graceful stop):
              * default: Up to 600 looping VUs for 2m40s over 5 stages (gracefulRampDown: 30s, gracefulStop: 30s)

INFO[0160] 
[Actuator] JVM live threads at end of test: 32  source=console


  █ THRESHOLDS 

    create_latency_ms
    ✓ 'p(99)<500' p(99)=118.31ms

    error_rate
    ✓ 'rate<0.01' rate=0.00%

    list_latency_ms
    ✓ 'p(99)<300' p(99)=73.91ms


  █ TOTAL RESULTS 

    checks_total.......: 759948  4746.113605/s
    checks_succeeded...: 100.00% 759948 out of 759948
    checks_failed......: 0.00%   0 out of 759948

    ✓ POST 201
    ✓ GET 200

    CUSTOM
    create_latency_ms..............: avg=104.77ms min=100.14ms med=103.72ms max=153.27ms p(90)=109.72ms p(95)=112.31ms
    error_rate.....................: 0.00%   0 out of 759948
    list_latency_ms................: avg=55.86ms  min=50.14ms  med=54.55ms  max=114.91ms p(90)=61.97ms  p(95)=65.09ms 

    HTTP
    http_req_duration..............: avg=54.79ms  min=86µs     med=54.55ms  max=153.27ms p(90)=105.69ms p(95)=108.13ms
      { expected_response:true }...: avg=54.79ms  min=86µs     med=54.55ms  max=153.27ms p(90)=105.69ms p(95)=108.13ms
    http_req_failed................: 0.00%   0 out of 1139923
    http_reqs......................: 1139923 7119.176653/s

    EXECUTION
    iteration_duration.............: avg=164.55ms min=150.5ms  med=162.1ms  max=255.94ms p(90)=177ms    p(95)=182.65ms
    iterations.....................: 379974  2373.056803/s
    vus............................: 4       min=4            max=600
    vus_max........................: 600     min=600          max=600

    NETWORK
    data_received..................: 17 GB   104 MB/s
    data_sent......................: 155 MB  966 kB/s




running (2m40.1s), 000/600 VUs, 379974 complete and 0 interrupted iterations
default ✓ [======================================] 000/600 VUs  2m40
~~~

<img width="486" height="249" alt="image" src="https://github.com/user-attachments/assets/70d82f39-d4a1-434c-bca8-d3853520b405" />

결과 해석

  JVM 쓰레드 217 → 32
  - 플랫폼 쓰레드: Tomcat 200개 + 시스템 ~17개 = 217개
  - 버추얼 쓰레드: carrier thread(ForkJoinPool) + 시스템 = 32개
  - 600개 요청을 처리하는 데 실제 OS 쓰레드는 32개면 충분

  P99 latency가 sleep 시간에 근접
  POST: sleep 100ms → P99 118ms (overhead 18ms만 추가)
  GET:  sleep  50ms → P99  74ms (overhead 24ms만 추가)
  쓰레드 풀 포화로 인한 큐 대기가 완전히 사라졌습니다.

  플랫폼 쓰레드가 느린 이유
  600 VU → 동시 점유 쓰레드 ~257개 필요
  Tomcat 쓰레드 풀 200개 → 57개 큐 대기
  → POST P99에 큐 대기 시간 ~134ms 추가

 버추얼 쓰레드 전환만으로 동일 하드웨어에서 처리량 2배, P99 레이턴시 절반이라는 결과가 나왔습니다.